### PR TITLE
Add Contabilidade service to calculator

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,16 @@
         <div class="marcadores-slider" id="sliderLabels"></div>
       </div>      
       <h4 class="titulo-servicos">Serviços adicionais</h4>
+      <div class="servico destaque" id="contabilidadeServico">
+        <span>Contabilidade<br><small>a partir de R$ 297</small></span>
+        <label class="switch"><input type="checkbox" id="contabilidadeToggle"><span class="slider"></span></label>
+      </div>
+      <div class="servico" id="funcionariosDiv" style="display:none;">
+        <span>Quantidade de funcionários<br><small>R$ 35/mês por funcionário</small></span>
+        <select id="funcionariosSelect">
+          <option>1</option><option>2</option><option>3</option><option>4</option><option>5</option><option>6</option><option>7</option><option>8</option><option>9</option><option>10</option>
+        </select>
+      </div>
       <div class="servico">
         <span>Quantidade de contas bancárias<br><small>R$ 100/mês por conta</small></span>
         <select id="contasSelect"><option>1</option><option>2</option><option>3</option><option>4</option><option>5</option><option>6</option><option>7</option><option>8</option></select>

--- a/script.js
+++ b/script.js
@@ -4,6 +4,9 @@ const contasSelect = document.getElementById("contasSelect");
 const cnpjsSelect = document.getElementById("cnpjsSelect");
 const consultorToggle = document.getElementById("consultorToggle");
 const powerbiToggle = document.getElementById("powerbiToggle");
+const contabilidadeToggle = document.getElementById("contabilidadeToggle");
+const funcionariosSelect = document.getElementById("funcionariosSelect");
+const funcionariosDiv = document.getElementById("funcionariosDiv");
 const precoTotal = document.getElementById("precoTotal");
 const volumeInfo = document.getElementById("volumeInfo");
 const planoNomeTopo = document.getElementById("planoNomeTopo");
@@ -52,6 +55,8 @@ function calcularTotal() {
   const cnpjs = Number(cnpjsSelect.value);
   const consultor = consultorToggle.checked;
   const powerbi = powerbiToggle.checked;
+  const contabilidade = contabilidadeToggle.checked;
+  const funcionarios = Number(funcionariosSelect.value);
 
   let plano = "Essencial";
   let precoBaseValor = 400;
@@ -74,6 +79,19 @@ function calcularTotal() {
   let total = precoBaseValor;
   const itensExtras = document.getElementById("itensExtras");
   itensExtras.innerHTML = "";
+
+  // Contabilidade
+  if (contabilidade) {
+    funcionariosDiv.style.display = "flex";
+    const valorCont = 297 + funcionarios * 35;
+    total += valorCont;
+    const linha = document.createElement("div");
+    linha.className = "preco-linha";
+    linha.innerHTML = `<span>Contabilidade (${funcionarios} funcionário${funcionarios !== 1 ? 's' : ''})</span><span>R$ ${valorCont}</span>`;
+    itensExtras.appendChild(linha);
+  } else {
+    funcionariosDiv.style.display = "none";
+  }
   // Transações
   if (transacoes <= transacoesInclusas) {
     volumeInfoLabel.textContent = `${transacoesInclusas} transações/mês`;
@@ -143,6 +161,8 @@ contasSelect.addEventListener("change", calcularTotal);
 cnpjsSelect.addEventListener("change", calcularTotal);
 consultorToggle.addEventListener("change", calcularTotal);
 powerbiToggle.addEventListener("change", calcularTotal);
+contabilidadeToggle.addEventListener("change", calcularTotal);
+funcionariosSelect.addEventListener("change", calcularTotal);
 
 // Inicializa
 calcularTotal();
@@ -157,6 +177,8 @@ if (contratarBtn) {
     const cnpjs = cnpjsSelect.value;
     const consultor = consultorToggle.checked;
     const powerbi = powerbiToggle.checked;
+    const contabilidade = contabilidadeToggle.checked;
+    const funcionarios = funcionariosSelect.value;
     const plano = planoNome.textContent;
     const total = precoTotal.textContent;
 
@@ -164,6 +186,7 @@ if (contratarBtn) {
                   `- ${transacoes} transações/mês%0A` +
                   `- ${contas} conta(s) bancária(s)%0A` +
                   `- ${cnpjs} CNPJ(s)%0A` +
+                  `- Contabilidade: ${contabilidade ? funcionarios + ' funcionário(s)' : 'Não'}%0A` +
                   `- Consultor dedicado: ${consultor ? 'Sim' : 'Não'}%0A` +
                   `- Integração com Power BI: ${powerbi ? 'Sim' : 'Não'}%0A` +
                   `- Total estimado: ${total}%0A`;

--- a/style.css
+++ b/style.css
@@ -108,6 +108,12 @@ input[type="range"]::-ms-thumb {
   align-items: center;
   margin-bottom: 16px;
 }
+.servico.destaque {
+  background-color: #fff8e6;
+  border-left: 4px solid #ffc107;
+  padding: 8px;
+  border-radius: 8px;
+}
 .servico select {
   font-family: 'Poppins', sans-serif;
   font-size: 13px;


### PR DESCRIPTION
## Summary
- add Contabilidade extra service option with employee count field
- support Contabilidade calculations in logic
- highlight Contabilidade field via CSS
- include Contabilidade details in WhatsApp contact message

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688bc6633334832d9e32f78ea1ada407