### PR TITLE
Refine Contabilidade option and add pricing note

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,18 @@
         <div class="marcadores-slider" id="sliderLabels"></div>
       </div>      
       <h4 class="titulo-servicos">Serviços adicionais</h4>
+      <div class="servico destaque" id="contabilidadeServico">
+        <div class="linha-servico">
+          <span>Contabilidade<br><small id="contabilidadePreco">a partir de R$ 297</small></span>
+          <label class="switch"><input type="checkbox" id="contabilidadeToggle"><span class="slider"></span></label>
+        </div>
+        <div class="linha-servico" id="funcionariosDiv" style="display:none;">
+          <span>Quantidade de funcionários<br><small>R$ 35/mês por funcionário</small></span>
+          <select id="funcionariosSelect">
+            <option value="0">0</option><option value="1">1</option><option value="2">2</option><option value="3">3</option><option value="4">4</option><option value="5">5</option><option value="6">6</option><option value="7">7</option><option value="8">8</option><option value="9">9</option><option value="10">10</option><option value="11">10+</option>
+          </select>
+        </div>
+      </div>
       <div class="servico">
         <span>Quantidade de contas bancárias<br><small>R$ 100/mês por conta</small></span>
         <select id="contasSelect"><option>1</option><option>2</option><option>3</option><option>4</option><option>5</option><option>6</option><option>7</option><option>8</option></select>
@@ -73,6 +85,7 @@
         <span id="precoTotal">R$ 400/mês</span>
       </div>
       <button id="contratarBtn">Contratar plano personalizado</button>
+      <p class="nota-rodape">Preço válido apenas para empresas de serviço do Simples Nacional. Para empresas no lucro presumido, lucro real ou em atividades de comércio ou indústria, consulte um de nossos consultores.</p>
     </div>
   </div>
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -4,6 +4,10 @@ const contasSelect = document.getElementById("contasSelect");
 const cnpjsSelect = document.getElementById("cnpjsSelect");
 const consultorToggle = document.getElementById("consultorToggle");
 const powerbiToggle = document.getElementById("powerbiToggle");
+const contabilidadeToggle = document.getElementById("contabilidadeToggle");
+const funcionariosSelect = document.getElementById("funcionariosSelect");
+const funcionariosDiv = document.getElementById("funcionariosDiv");
+const contabilidadePrecoLabel = document.getElementById("contabilidadePreco");
 const precoTotal = document.getElementById("precoTotal");
 const volumeInfo = document.getElementById("volumeInfo");
 const planoNomeTopo = document.getElementById("planoNomeTopo");
@@ -52,6 +56,8 @@ function calcularTotal() {
   const cnpjs = Number(cnpjsSelect.value);
   const consultor = consultorToggle.checked;
   const powerbi = powerbiToggle.checked;
+  const contabilidade = contabilidadeToggle.checked;
+  const funcionarios = Number(funcionariosSelect.value);
 
   let plano = "Essencial";
   let precoBaseValor = 400;
@@ -74,6 +80,27 @@ function calcularTotal() {
   let total = precoBaseValor;
   const itensExtras = document.getElementById("itensExtras");
   itensExtras.innerHTML = "";
+
+  const funcionariosTexto = funcionariosSelect.options[funcionariosSelect.selectedIndex].text;
+  const contabilidadeConsultar = transacoes > 400 && funcionarios > 10;
+
+  // Atualiza texto do serviço
+  contabilidadePrecoLabel.textContent = contabilidadeConsultar ? "Consultar" : "a partir de R$ 297";
+
+  funcionariosDiv.style.display = contabilidade ? "flex" : "none";
+
+  if (contabilidade) {
+    const linha = document.createElement("div");
+    linha.className = "preco-linha";
+    if (contabilidadeConsultar) {
+      linha.innerHTML = `<span>Contabilidade (${funcionariosTexto} funcionário${funcionarios !== 1 ? 's' : ''})</span><span>Consultar</span>`;
+    } else {
+      const valorCont = 297 + funcionarios * 35;
+      total += valorCont;
+      linha.innerHTML = `<span>Contabilidade (${funcionariosTexto} funcionário${funcionarios !== 1 ? 's' : ''})</span><span>R$ ${valorCont}</span>`;
+    }
+    itensExtras.appendChild(linha);
+  }
   // Transações
   if (transacoes <= transacoesInclusas) {
     volumeInfoLabel.textContent = `${transacoesInclusas} transações/mês`;
@@ -143,6 +170,8 @@ contasSelect.addEventListener("change", calcularTotal);
 cnpjsSelect.addEventListener("change", calcularTotal);
 consultorToggle.addEventListener("change", calcularTotal);
 powerbiToggle.addEventListener("change", calcularTotal);
+contabilidadeToggle.addEventListener("change", calcularTotal);
+funcionariosSelect.addEventListener("change", calcularTotal);
 
 // Inicializa
 calcularTotal();
@@ -157,6 +186,9 @@ if (contratarBtn) {
     const cnpjs = cnpjsSelect.value;
     const consultor = consultorToggle.checked;
     const powerbi = powerbiToggle.checked;
+    const contabilidade = contabilidadeToggle.checked;
+    const funcionarios = funcionariosSelect.value;
+    const funcionariosTexto = funcionariosSelect.options[funcionariosSelect.selectedIndex].text;
     const plano = planoNome.textContent;
     const total = precoTotal.textContent;
 
@@ -164,6 +196,7 @@ if (contratarBtn) {
                   `- ${transacoes} transações/mês%0A` +
                   `- ${contas} conta(s) bancária(s)%0A` +
                   `- ${cnpjs} CNPJ(s)%0A` +
+                  `- Contabilidade: ${contabilidade ? funcionariosTexto + ' funcionário(s)' : 'Não'}%0A` +
                   `- Consultor dedicado: ${consultor ? 'Sim' : 'Não'}%0A` +
                   `- Integração com Power BI: ${powerbi ? 'Sim' : 'Não'}%0A` +
                   `- Total estimado: ${total}%0A`;

--- a/style.css
+++ b/style.css
@@ -108,6 +108,30 @@ input[type="range"]::-ms-thumb {
   align-items: center;
   margin-bottom: 16px;
 }
+.servico.destaque {
+  background-color: #fff8e6;
+  border-left: 4px solid #ffc107;
+  padding: 8px;
+  border-radius: 8px;
+}
+
+#contabilidadeServico {
+  flex-direction: column;
+  gap: 8px;
+}
+
+#contabilidadeServico .linha-servico {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.nota-rodape {
+  font-size: 11px;
+  color: #666;
+  margin-top: 8px;
+  line-height: 1.3;
+}
 .servico select {
   font-family: 'Poppins', sans-serif;
   font-size: 13px;


### PR DESCRIPTION
## Summary
- embed employee selector inside highlighted Contabilidade service
- start employee count at 0 and cap at 10+
- show "Consultar" price when >400 transactions and >10 employees
- exclude Contabilidade cost when consulting and update label
- add note about Simples Nacional pricing

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688bc6633334832d9e32f78ea1ada407