### PR TITLE
Update contabilidade layout toggle and input style

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
         <div class="marcadores-slider" id="sliderLabels"></div>
       </div>      
       <h4 class="titulo-servicos">Serviços adicionais</h4>
-      <div class="servico destaque" id="contabilidadeServico">
+      <div class="servico contabilidade" id="contabilidadeServico">
         <div class="info">
           <span>Contabilidade<sup>1</sup><br><small id="contabilidadePreco">a partir de R$ 297</small></span>
           <div id="funcionariosDiv" class="funcionarios" style="display:none;">
@@ -36,6 +36,7 @@
         </div>
         <label class="switch"><input type="checkbox" id="contabilidadeToggle"><span class="slider"></span></label>
       </div>
+      <hr class="servico-separator" />
       <div class="servico">
         <span>Quantidade de contas bancárias<br><small>R$ 100/mês por conta</small></span>
         <select id="contasSelect"><option>1</option><option>2</option><option>3</option><option>4</option><option>5</option><option>6</option><option>7</option><option>8</option></select>

--- a/style.css
+++ b/style.css
@@ -110,9 +110,9 @@ input[type="range"]::-ms-thumb {
   gap: 8px;
   margin-bottom: 16px;
 }
-.servico.destaque {
-  background-color: #fff8e6;
-  border-left: 4px solid #ffc107;
+.servico.contabilidade {
+  background-color: #fffdf5;
+  border-left: 2px solid #ffdda9;
   padding: 8px;
   border-radius: 8px;
   align-items: flex-start;
@@ -170,12 +170,11 @@ input[type="range"]::-ms-thumb {
   font-family: 'Poppins', sans-serif;
   font-size: 13px;
   height: 32px;
-  width: 70px;
-  padding: 4px 10px;
+  min-width: 52px;
+  padding: 4px 12px 4px 10px;
   border: 1px solid #ddd;
   border-radius: 20px;
   background-color: #f9f9f9;
-  text-align: right;
   transition: border 0.2s ease, background-color 0.2s ease;
 }
 .servico input[type="number"]:hover {
@@ -324,4 +323,10 @@ button {
   color: #555;
   margin-top: auto;
   line-height: 1.2;
+}
+
+.servico-separator {
+  border: none;
+  border-top: 1px solid #eee;
+  margin: 12px 0;
 }


### PR DESCRIPTION
## Summary
- put subtle separator after Contabilidade service
- show employee count only when accounting is enabled
- match employee input dimensions to account and CNPJ selectors
- highlight Contabilidade service with subtle style instead of destaque class

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_688d12d7e49c832d80e4bc3de38f7a36